### PR TITLE
Cmake collision fixes

### DIFF
--- a/minimake.sh
+++ b/minimake.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 
-###################################################################
-#Script Name	: minimake.sh                   
-#Description	: build cmake, compile, test, clean                                                                   
-#Args           : none, test, clean                                                                                          
-#Author       	: Stan Verschuuren                                                
-#Email         	: sverschu@student.codam.nl
-#Github         : https://github.com/s-t-a-n
-###################################################################
-
+# https://github.com/s-t-a-n
 build_dir=build
 
 if [ $# -eq 1 ] && [ "$1" == "test" ]; then
@@ -24,7 +16,7 @@ elif [ $# -eq 0 ]; then
 	# compile and copy hashmap binary and lib to root folder
 	cmake -S . -B $build_dir -DBUILD_TESTING=OFF && ( cd $build_dir && make ) \
 	&& cp $build_dir/src/libhashmap.a ./ \
-	&& echo -e "You can run ./\e[92mhashmap\e[39m now or include \e[92mlibhashmap.a\e[39m in your library." \
+	&& echo -e "You can include \e[92mlibhashmap.a\e[39m in your library." \
 	|| { echo -e "Compilation ran: \e[91mNOPE\e[39m."; false; }
 else
 	cat<<-EOF

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,11 +4,27 @@ FetchContent_Declare(
   GIT_TAG        v2.13.4)
 FetchContent_MakeAvailable(Catch2)
 
-## All unittests
-set (TEST "test-all")
-file(GLOB SRC_LIST CONFIGURE_DEPENDS "src/*.cpp")
+#### Combined unittest
 
-add_executable(${TEST}.bin ${SRC_LIST})
+if((CMAKE_PROJECT_NAME STREQUAL hashmap OR MODERN_CMAKE_BUILD_TESTING))
+  set (TEST "test-all")
+  file(GLOB SRC_LIST CONFIGURE_DEPENDS "src/*.cpp")
+  
+  add_executable(${TEST}.bin ${SRC_LIST})
+  target_compile_features(${TEST}.bin PRIVATE cxx_std_14)
+  target_link_libraries(${TEST}.bin PRIVATE Catch2::Catch2WithMain)
+  target_link_libraries(${TEST}.bin PRIVATE hashmap ft)
+  add_test(NAME ${TEST}
+  		COMMAND ${TEST}.bin)
+endif()
+
+#### Individual unittests
+
+### Hashmap unittest
+set (TEST "test-hashmap")
+set (SRC_LIST "src/hashmap.cpp")
+
+add_executable(${TEST}.bin ${MAIN} ${SRC_LIST})
 target_compile_features(${TEST}.bin PRIVATE cxx_std_14)
 target_link_libraries(${TEST}.bin PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(${TEST}.bin PRIVATE hashmap ft)
@@ -16,8 +32,8 @@ add_test(NAME ${TEST}
 		COMMAND ${TEST}.bin)
 
 ### Hashmap unittest
-set (TEST "test-hashmap")
-set (SRC_LIST "src/hashmap.cpp")
+set (TEST "test-hashmap-collision")
+set (SRC_LIST "src/hashmap_collisions.cpp")
 
 add_executable(${TEST}.bin ${MAIN} ${SRC_LIST})
 target_compile_features(${TEST}.bin PRIVATE cxx_std_14)


### PR DESCRIPTION
so you can add unittests from inside other project without collision of build targets